### PR TITLE
Make completion options overridable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
         restore-keys: ${{ runner.os }}-vscode-test-
     - name: ⚡ Run headless test
       run: |
-        sudo mkdir /run/dbus
+        [ ! -e /run/dbus ] && sudo mkdir /run/dbus
         dbus-daemon --session --address=unix:path=/run/dbus/system_bus_socket --nofork &
         DBUS_SESSION_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket xvfb-run npm test
         ps aux | grep -e [t]mp/xvfb-run -e [d]bus-daemon | awk '{print $2}' | sudo xargs kill

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to the **Markdown Copilot** extension will be documented in 
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## [Unreleased]
+## [0.0.2] - 2024-02-21
+### Added
+- Allow specifying override options via Markdown
 
+## [0.0.1] - 2024-02-20
+### Added
 - Initial release
+- Markdown completion
+- Cancel running completions
+- Settings
+- Refactor for code reuse
+- Quote indentation
+- Localization
+  - English
+  - Japanese
+  - Simplified Chinese
+- Documentation
+- Review Markdown notation
+- Publish to marketplace
+
+
+[0.0.2]: https://github.com/kurusugawa-computer/markdown-copilot-vscode/compare/v0.0.1...v0.0.2
+[0.0.1]: https://github.com/kurusugawa-computer/markdown-copilot-vscode/releases/tag/v0.0.1

--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@
 
 <picture><img src="https://github.com/kurusugawa-computer/markdown-copilot-vscode/raw/main/images/markdown-copilot.gif" alt="Basic Usage" width="1024"></picture>
 
-Elevate your Markdown editing experience in Visual Studio Code with Markdown Copilot, your AI-powered assistant. Whether you're crafting documentation, jotting down notes, or creating any Markdown content, Markdown Copilot offers intelligent, real-time suggestions to enhance your writing process. With advanced features like Parallel Editing, Context Control, and Quote Indentation, Markdown Copilot ensures your writing is not just efficient but also precise and easy.
+Markdown Copilot enables you to fully replace the OpenAI ChatGPT WebUI, offering superior features such as:
+1. Saving conversation histories in Markdown
+2. Asking multiple questions simultaneously
+3. Branching out conversations
+4. Editing previous conversations at any point and continuing the dialogue
 
-***Note***: An OpenAI API Key is required to use this extension. For more information, please refer to [the OpenAI official FAQ](https://help.openai.com/en/articles/4936850-where-do-i-find-my-api-key).
+***Note***: An OpenAI API Key is required to use this extension. For more information, please refer to the [OpenAI official FAQ](https://help.openai.com/en/articles/4936850-where-do-i-find-my-api-key).
 
 ## Key Features
 
@@ -59,6 +63,24 @@ More complex example: the context continues across `take care` line.
 
 <picture><img src="https://github.com/kurusugawa-computer/markdown-copilot-vscode/raw/main/images/context-notation-example-seeyouagain.png" alt="Example: see you again" width="512"></picture>
 
+#### Override Options
+
+Customize Markdown Copilot's behavior with override options. This allows you to control settings like response length or the AI model directly within your document.
+
+To use override options, simply include a JSON code block labeled `json copilot-options` with your desired settings, then select this block along with your text and choose `💡 Markdown Copilot: Continue` from the code action proposals.
+
+Example: Let Markdown Copilot introduce itself with customized response length and model:
+
+````markdown
+Introduce yourself.
+
+```json copilot-options
+{"max_tokens":50,"model":"gpt-3.5-turbo"}
+```
+````
+
+For more configuration options, please refer to the [OpenAI API: Create chat completion](https://platform.openai.com/docs/api-reference/chat/create).
+
 ### Quote Indentation
 
 Simplify the editing of quote indentation levels with intuitive actions.
@@ -104,7 +126,8 @@ Combine Markdown Copilot with these extensions for an even more powerful Markdow
   - [x] Simplified Chinese
 - [x] Documentation
 - [x] Review Markdown notation
-- [ ] Publish to marketplace
+- [x] Publish to marketplace
+- [x] Make options overridable
 - [ ] Prompt templates
 - [ ] Importing files
 - [ ] Image Generation: DALL·E

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Markdown Copilot",
   "description": "%extension.description%",
   "icon": "images/icon-128x128.png",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "publisher": "kurusugawa-computer",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
## Override Options

Customize Markdown Copilot's behavior with override options. This allows you to control settings like response length or the AI model directly within your document.

To use override options, simply include a JSON code block labeled `json copilot-options` with your desired settings, then select this block along with your text and choose `💡 Markdown Copilot: Continue` from the code action proposals.

Example: Let Markdown Copilot introduce itself with customized response length and model:

````markdown
Introduce yourself.

```json copilot-options
{"max_tokens":50,"model":"gpt-3.5-turbo"}
```
````

For more configuration options, please refer to the [OpenAI API: Create chat completion](https://platform.openai.com/docs/api-reference/chat/create).