### PR TITLE
Support document inclusion

### DIFF
--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -2,6 +2,7 @@
     "extension.description": "VSCode 用 OpenAI ChatGPT API クライアント",
     "command.editing.continueInContext.title": "Markdown Copilot: コンテキストの中で続ける",
     "command.editing.continueInContext.detail": "コンテキストに基づいて編集を続ける",
+    "command.editing.continueInContext.import.error": "{0}のインポート中にエラーが発生しました",
     "command.editing.continueWithoutContext.title": "Markdown Copilot: コンテキストを無視して続ける",
     "command.editing.continueWithoutContext.detail": "コンテキストを無視して編集を続ける",
     "command.editing.indentQuote.title": "Markdown Copilot: 引用行をインデント",

--- a/package.nls.json
+++ b/package.nls.json
@@ -2,6 +2,7 @@
     "extension.description": "An OpenAI ChatGPT API client for VSCode",
     "command.editing.continueInContext.title": "Markdown Copilot: Continue in context",
     "command.editing.continueInContext.detail": "Continue editing based on context",
+    "command.editing.continueInContext.import.error": "Error occurred while importing {0}",
     "command.editing.continueWithoutContext.title": "Markdown Copilot: Continue without context",
     "command.editing.continueWithoutContext.detail": "Continue editing without context",
     "command.editing.indentQuote.title": "Markdown Copilot: Indent Quote Line",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -4,6 +4,7 @@
     "command.editing.continueInContext.detail": "根据上下文继续编辑",
     "command.editing.continueWithoutContext.title": "Markdown Copilot: 无上下文继续",
     "command.editing.continueWithoutContext.detail": "无上下文继续编辑",
+    "command.editing.continueInContext.import.error": "在导入{0}时发生了错误",
     "command.editing.indentQuote.title": "Markdown Copilot: 缩进引号行",
     "command.editing.outdentQuote.title": "Markdown Copilot: 减少缩进报价行",
     "command.editing.titleActiveContext.title": "Markdown Copilot: 活动上下文标题",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -622,8 +622,12 @@ async function continueEditing(outline: DocumentOutline, useContext: boolean, se
 					const workspaceFolder = vscode.workspace.workspaceFolders[0].uri;
 					const filename = match[1];
 					const fullPath = vscode.Uri.joinPath(workspaceFolder, filename);
-					const doc = await vscode.workspace.openTextDocument(fullPath);
-					activeLineTexts.push(doc.getText());
+					try {
+						const doc = await vscode.workspace.openTextDocument(fullPath);
+						activeLineTexts.push(doc.getText());
+					} catch {
+						vscode.window.showErrorMessage(`Error occurred while importing ${filename}`);
+					}
 				} else {
 					activeLineTexts.push(line);
 				}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,11 +17,11 @@ export function activate(context: vscode.ExtensionContext) {
 	const COMMAND_MARKDOWN_COPILOT_EDITING_OUTDENT_QUOTE = "markdown.copilot.editing.outdentQuote";
 
 	context.subscriptions.push(vscode.commands.registerCommand(COMMAND_MARKDOWN_COPILOT_EDITING_CONTINUE_IN_CONTEXT,
-		async (selectionOverride?: vscode.Selection) => await continueEditing(outline, true, selectionOverride)
+		(selectionOverride?: vscode.Selection) => continueEditing(outline, true, selectionOverride)
 	));
 
 	context.subscriptions.push(vscode.commands.registerCommand(COMMAND_MARKDOWN_COPILOT_EDITING_CONTINUE_WITHOUT_CONTEXT,
-		async (selectionOverride?: vscode.Selection) => await continueEditing(outline, false, selectionOverride)
+		(selectionOverride?: vscode.Selection) => continueEditing(outline, false, selectionOverride)
 	));
 
 	context.subscriptions.push(vscode.commands.registerCommand(COMMAND_MARKDOWN_COPILOT_EDITING_TITLE_ACTIVE_CONTEXT, async () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -626,7 +626,16 @@ async function continueEditing(outline: DocumentOutline, useContext: boolean, se
 						const doc = await vscode.workspace.openTextDocument(fullPath);
 						activeLineTexts.push(doc.getText());
 					} catch {
-						vscode.window.showErrorMessage(l10n.t("command.editing.continueInContext.import.error", filename));
+						const message = l10n.t("command.editing.continueInContext.import.error", filename);
+						const textEditor = vscode.window.activeTextEditor;
+						const decorationType = vscode.window.createTextEditorDecorationType({
+							after: {
+								contentText: message,
+								color: 'rgba(128, 128, 128, 0.7)'
+							}
+						});
+						textEditor?.setDecorations(decorationType, [new vscode.Range(userEnd, userEnd)]);
+						vscode.window.showErrorMessage(message).then(() => decorationType.dispose());
 					}
 				} else {
 					activeLineTexts.push(line);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -626,7 +626,7 @@ async function continueEditing(outline: DocumentOutline, useContext: boolean, se
 						const doc = await vscode.workspace.openTextDocument(fullPath);
 						activeLineTexts.push(doc.getText());
 					} catch {
-						vscode.window.showErrorMessage(`Error occurred while importing ${filename}`);
+						vscode.window.showErrorMessage(l10n.t("command.editing.continueInContext.import.error", filename));
 					}
 				} else {
 					activeLineTexts.push(line);


### PR DESCRIPTION
### Summary

- Issue: #3
- Adds support for syntax `@import "markdown.md"`, which inserts file content into the active context.
  - This syntax is supported by Markdown Preview Enhanced.