### PR TITLE
モデルのデフォルト値を`gpt-4o`から`gpt-4.1`に変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -245,7 +245,7 @@
             "gpt-3.5-turbo-0613",
             "→ Model Name Text"
           ],
-          "default": "gpt-4o",
+          "default": "gpt-4.1",
           "markdownDescription": "%config.options.model.description%"
         },
         "markdown.copilot.options.modelNameText": {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -12,7 +12,7 @@ suite('Extension Test Suite', () => {
 		const configuration = vscode.workspace.getConfiguration();
 		assert.strictEqual(0.5, configuration.get<number>("markdown.copilot.context.inactiveOpacity"));
 		assert.strictEqual("", configuration.get<string>("markdown.copilot.backend.apiKey"));
-		assert.strictEqual("gpt-4o", configuration.get<string>("markdown.copilot.options.model"));
+		assert.strictEqual("gpt-4.1", configuration.get<string>("markdown.copilot.options.model"));
 		assert.strictEqual(0.1, configuration.get<number>("markdown.copilot.options.temperature"));
 	});
 


### PR DESCRIPTION
costやintelligenceなどで比較しても、`gpt-4.1`の方が上回っているので、デフォルト値を変更しました。
![image](https://github.com/user-attachments/assets/ae8a9625-9112-4cff-8343-c9ae47f13314)
