### PR TITLE
GPT5関連のモデルを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,6 +212,13 @@
         "markdown.copilot.options.model": {
           "type": "string",
           "enum": [
+            "gpt-5-chat-latest",
+            "gpt-5-2025-08-07",
+            "gpt-5",
+            "gpt-5-mini-2025-08-07",
+            "gpt-5-mini",
+            "gpt-5-nano-2025-08-07",
+            "gpt-5-nano",
             "gpt-4o",
             "gpt-4o-search-preview",
             "gpt-4o-2024-11-20",


### PR DESCRIPTION
GPT5系のモデルを利用したかったので、追加しました。


以下のコマンドで取得したモデルの一覧から、GPT5関連のモデルを抽出しました。

```
curl https://api.openai.com/v1/models \
  -H "Authorization: Bearer $OPENAI_API_KEY"
 ```